### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SRC_DIR := src
 all: sync run
 
 sync:
-	@uv sync
+	@uv sync --no-cache
 run: sync
 	@uv run --directory $(SRC_DIR) streamlit run app.py --browser.gatherUsageStats false
 test: sync


### PR DESCRIPTION
This pull request makes a minor update to the `Makefile` to improve dependency management. The `sync` target now uses the `--no-cache` flag with the `uv sync` command to ensure dependencies are always freshly resolved.

- Dependency management:
  * Updated the `sync` target in `Makefile` to run `uv sync --no-cache`, ensuring dependencies are not pulled from cache.