### PR TITLE
Remove GitHub Copilot extension from configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,6 @@
     "vscode": {
       "extensions": [
         "DavidAnson.vscode-markdownlint",
-        "GitHub.copilot",
         "GitHub.copilot-chat",
         "Tyriar.sort-lines",
         "bradzacher.vscode-copy-filename",


### PR DESCRIPTION
This pull request makes a minor update to the `.devcontainer/devcontainer.json` configuration by removing the `GitHub.copilot` extension from the list of recommended VS Code extensions. This change will prevent the Copilot extension from being automatically suggested or installed in the dev container environment.Removed GitHub Copilot extension from devcontainer.