### PR TITLE
Remove GitHub Copilot Chat extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,6 @@
     "vscode": {
       "extensions": [
         "DavidAnson.vscode-markdownlint",
-        "GitHub.copilot-chat",
         "Tyriar.sort-lines",
         "bradzacher.vscode-copy-filename",
         "charliermarsh.ruff",


### PR DESCRIPTION
Removed GitHub Copilot Chat extension from devcontainer.